### PR TITLE
fix: exclude test classpath from spring-boot:run (#31)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+					<useTestClasspath>false</useTestClasspath>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
## Summary

- Adds `<useTestClasspath>false</useTestClasspath>` to the `spring-boot-maven-plugin` `<configuration>` block in `pom.xml`
- Prevents `src/test/resources` (including `application-ollama.yml`) from appearing on the classpath during `mvn spring-boot:run`
- Fixes the root cause of Liquibase failures in dev: `application-ollama.yml` was silently excluding `PreLiquibaseAutoConfiguration`, so preliquibase never created the `vectorcontent` schema before Liquibase ran

## Root cause

`application-ollama.yml` in `src/test/resources` contains:
```yaml
spring:
  autoconfigure:
    exclude: net.lbruun.springboot.preliquibase.PreLiquibaseAutoConfiguration
```

With `useTestClasspath` defaulting to `true` for `spring-boot:run`, this file was loaded at dev runtime, disabling preliquibase and causing Liquibase to fail immediately.

## Test plan

- [ ] Run `mvn spring-boot:run` — preliquibase should now create the `vectorcontent` schema before Liquibase runs
- [ ] Confirm no Liquibase schema-not-found errors in startup logs
- [ ] Run `mvn test` — existing tests should still pass (test classpath is unaffected for tests)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)