### PR TITLE
fix: Liquibase migration schema, metadata type, search_path hygiene, cleanup (#30)

### DIFF
--- a/src/main/resources/db/changelog/DocumentContent-DOC_MANAGEMENT_DB/sprint1/release1/ddl/CREATE-VECTOR-EXTENSION.sql
+++ b/src/main/resources/db/changelog/DocumentContent-DOC_MANAGEMENT_DB/sprint1/release1/ddl/CREATE-VECTOR-EXTENSION.sql
@@ -1,14 +1,12 @@
-SET SEARCH_PATH TO vectorcontent;
-
 CREATE EXTENSION IF NOT EXISTS vector;
-CREATE EXTENSION IF NOT EXISTS hstore;
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+SET SEARCH_PATH TO vectorcontent, public;
 
 CREATE TABLE IF NOT EXISTS vector_store (
-	id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
-	content text,
-	metadata json,
-	embedding vector(1536)
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    content text,
+    metadata jsonb,
+    embedding vector(1536)
 );
 
 CREATE INDEX ON vector_store USING HNSW (embedding vector_cosine_ops);

--- a/src/main/resources/db/changelog/DocumentContent-DOC_MANAGEMENT_DB/sprint1/release1/privileges/DATABASE-DDL-SEARCH-PATH.sql
+++ b/src/main/resources/db/changelog/DocumentContent-DOC_MANAGEMENT_DB/sprint1/release1/privileges/DATABASE-DDL-SEARCH-PATH.sql
@@ -1,2 +1,2 @@
-ALTER ROLE postgres SET search_path TO documentcontent, vectorcontent, public;
-ALTER ROLE doc_management_user SET search_path TO documentcontent, vectorcontent, public;
+ALTER ROLE postgres SET search_path TO vectorcontent, public;
+ALTER ROLE doc_management_user SET search_path TO vectorcontent, public;

--- a/src/main/resources/db/changelog/DocumentContent-DOC_MANAGEMENT_DB/sprint1/release2/ddl/ALTER-VECTOR-STORE-1024.sql
+++ b/src/main/resources/db/changelog/DocumentContent-DOC_MANAGEMENT_DB/sprint1/release2/ddl/ALTER-VECTOR-STORE-1024.sql
@@ -1,9 +1,11 @@
+SET SEARCH_PATH TO vectorcontent, public;
+
 DROP TABLE IF EXISTS vector_store;
 
 CREATE TABLE vector_store (
-    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
     content text,
-    metadata json,
+    metadata jsonb,
     embedding vector(1024)
 );
 


### PR DESCRIPTION
## Summary

- **ADR 0001 — Extension schema**: `CREATE EXTENSION vector` now runs before `SET SEARCH_PATH TO vectorcontent` so the type lands in `public` and is visible to all connections regardless of their session search_path. Fixes `PSQLException: Unknown type vector`.
- **Remove unused extensions**: `hstore` and `uuid-ossp` removed entirely from `CREATE-VECTOR-EXTENSION.sql`.
- **uuid function**: `uuid_generate_v4()` replaced with `gen_random_uuid()` (built-in since PG13; we run PG16) in both DDL files.
- **ADR 0003 — jsonb metadata**: `metadata json` changed to `metadata jsonb` in both `vector_store` table definitions. Spring AI uses the `@>` containment operator for metadata filters, which only works on `jsonb`.
- **Self-contained search_path**: `SET SEARCH_PATH TO vectorcontent, public;` added as the first statement in `ALTER-VECTOR-STORE-1024.sql` so it does not depend on session state from a prior changeset.
- **search_path hygiene**: `documentcontent` removed from both `ALTER ROLE` statements in `DATABASE-DDL-SEARCH-PATH.sql` — that schema was never created.
- **ADR 0004 — Modify in place**: Pre-production repo, no prod data; changesets modified directly.
- **Orphan file removed**: Empty `FUNCT1-create.sql` deleted (never referenced in any changelog XML).

## Test plan

- [ ] Run `mvn liquibase:clearCheckSums` or recreate Docker container before applying migrations
- [ ] Start application against a fresh PostgreSQL container — Liquibase migrations should run without errors
- [ ] Confirm `vector` extension is visible: `\dx` in psql should show `vector` in `public` schema
- [ ] Confirm `vector_store` table has `metadata jsonb` (not `json`): `\d vectorcontent.vector_store`
- [ ] Confirm Spring AI metadata filter queries (`@>` operator) work without casting errors
- [ ] Confirm no references to `hstore`, `uuid-ossp`, or `uuid_generate_v4` remain in migration files
- [ ] Confirm `FUNCT1-create.sql` is gone from the repository

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)