### PR TITLE
fix: sync test-init.sql with corrected schema (#32)

### DIFF
--- a/src/test/resources/test-init.sql
+++ b/src/test/resources/test-init.sql
@@ -2,13 +2,11 @@ CREATE ROLE doc_management_user WITH LOGIN PASSWORD 'toor';
 CREATE SCHEMA IF NOT EXISTS vectorcontent;
 
 CREATE EXTENSION IF NOT EXISTS vector;
-CREATE EXTENSION IF NOT EXISTS hstore;
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CREATE TABLE IF NOT EXISTS vectorcontent.vector_store (
-    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
     content text,
-    metadata json,
+    metadata jsonb,
     embedding vector(1024)
 );
 


### PR DESCRIPTION
## Summary

- Removes unused `hstore` and `uuid-ossp` extensions from `test-init.sql`
- Replaces `uuid_generate_v4()` with `gen_random_uuid()` (no extension needed)
- Changes `metadata json` → `metadata jsonb` to mirror the production Liquibase migration

Closes #32. Mirrors the schema corrections from issue #30 (`fix/issue-30-migration-schema`).

## Test plan

- [x] `contextLoads` — PASSED
- [x] `givenDocumentIngested_whenAskMatchingQuestion_thenAnswerReturned` — PASSED
- [x] `givenNoDocuments_whenAskQuestion_thenFallbackAnswerReturned` — PASSED

All three `DocumentAiRepositoryIT` tests pass with `mvn test -P windows-docker-desktop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)